### PR TITLE
Ensure npm links console utility on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "enforce winding order for geojson",
   "main": "index.js",
+  "bin": "geojson-rewind",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
The `geojson-rewind` commands was not linked on install, preventing it to be used as a console utility.
Adding the command in the `bin` section of the `package.json` solves the issue.