### PR TITLE
IETF rfc7946 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 
 # geojson-rewind
 
-The [GeoJSON](http://geojson.org/) specification is not picky about winding order, but
-this is.
+The [GeoJSON](https://tools.ietf.org/html/rfc7946) specification is picky about winding order.
 
-This lets you use [Canvas](http://www.bit-101.com/blog/?p=3702) and other drawing
-libraries's default behavior to color the interior rings of Polygon and MultiPolygon
-features.
+This helps you generate compliant Polygon and MultiPolygon geometries. Furthermore it lets you use [Canvas](http://www.bit-101.com/blog/?p=3702) and other drawing libraries's default behavior to color the interior rings of Polygon and MultiPolygon features.
 
 ## usage
 


### PR DESCRIPTION
This updates the readme to show the fact that having correct winding order is now necessary for valid GeoJSON (after rfc7946).