### PR TITLE
Update to latest deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "tap test/rewind.js --coverage"
+    "test": "tape test/rewind.js"
   },
   "repository": {
     "type": "git",
@@ -28,13 +28,13 @@
   },
   "homepage": "https://github.com/mapbox/geojson-rewind",
   "dependencies": {
-    "@mapbox/geojson-area": "0.2.1",
-    "minimist": "1.2.0",
-    "concat-stream": "~1.5.2"
+    "@mapbox/geojson-area": "0.2.2",
+    "concat-stream": "~1.6.0",
+    "minimist": "1.2.0"
   },
   "devDependencies": {
-    "cz-conventional-changelog": "^1.2.0",
-    "tap": "~8.0.1"
+    "cz-conventional-changelog": "^2.0.0",
+    "tape": "^4.8.0"
   },
   "config": {
     "commitizen": {

--- a/test/rewind.js
+++ b/test/rewind.js
@@ -1,6 +1,6 @@
 var rewind = require('../'),
     fs = require('fs'),
-    test = require('tap').test;
+    test = require('tape');
 
 function f(_) {
     return JSON.parse(fs.readFileSync(_, 'utf8'));


### PR DESCRIPTION
Update to latest deps and switch to node-tape which has become the standard test runner that we use.