### PR TITLE
add missing sharkdown dependency

### DIFF
--- a/geojson-rewind
+++ b/geojson-rewind
@@ -3,6 +3,7 @@
 var rewind = require('./'),
     concat = require('concat-stream'),
     fs = require('fs'),
+    sharkdown = require('sharkdown'),
     argv = require('minimist')(process.argv.slice(2), {
         boolean: 'counterclockwise'
     });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@mapbox/geojson-area": "0.2.2",
     "concat-stream": "~1.6.0",
-    "minimist": "1.2.0"
+    "minimist": "1.2.0",
+    "sharkdown": "^0.1.0"
   },
   "devDependencies": {
     "cz-conventional-changelog": "^2.0.0",


### PR DESCRIPTION
Closes #10.

Currently due to #10, running `geojson-rewind -h` errors with `ReferenceError: sharkdown is not defined`. This PR fixes that.