### PR TITLE
Replace concat-stream with get-stream

### DIFF
--- a/geojson-rewind
+++ b/geojson-rewind
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var rewind = require('./'),
-    concat = require('concat-stream'),
+    getStream = require('get-stream'),
     fs = require('fs'),
     argv = require('minimist')(process.argv.slice(2), {
         boolean: 'clockwise'
@@ -25,7 +25,8 @@ if (process.stdin.isTTY && !argv._[0]) {
     process.exit(1);
 }
 
-(argv._.length ? fs.createReadStream(argv._[0]) : process.stdin).pipe(concat(convert));
+getStream(argv._.length ? fs.createReadStream(argv._[0]) : process.stdin)
+  .then(convert);
 
 function convert(data) {
     process.stdout.write(JSON.stringify(rewind(JSON.parse(data), argv.clockwise)));

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/mapbox/geojson-rewind",
   "dependencies": {
-    "concat-stream": "~2.0.0",
+    "get-stream": "^6.0.0",
     "minimist": "^1.2.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Concat-strem is quite big project with many dependencies. Mostly because
of old node support. https://packagephobia.com/result?p=concat-stream

Get-stream is modern promise based alternative.
https://packagephobia.com/result?p=get-stream