### PR TITLE
Migrate to github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: main
+on:
+  - pull_request
+  - push
+jobs:
+  main:
+    name: '${{ matrix.node }}'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - run: npm test
+    strategy:
+      matrix:
+        node:
+          - 10
+          - node

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - 10
-  - node


### PR DESCRIPTION
Travis started hanging everywhere because of changed open source plan.
Github actions is the simplest solution now.