### PR TITLE
Make the module ES modules compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Build artefacts
+index.cjs
+
 # Logs
 logs
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 10
+  - 12
   - node

--- a/geojson-rewind.js
+++ b/geojson-rewind.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
-var rewind = require('./'),
-    getStream = require('get-stream'),
-    fs = require('fs'),
-    argv = require('minimist')(process.argv.slice(2), {
-        boolean: 'clockwise'
-    });
+import rewind from "@mapbox/geojson-rewind";
+import getStream from "get-stream";
+import fs from "fs";
+import minimist from "minimist";
+
+const argv = minimist(process.argv.slice(2), {
+    boolean: 'clockwise'
+});
 
 const help = `
 usage:

--- a/index.js
+++ b/index.js
@@ -1,7 +1,4 @@
-
-module.exports = rewind;
-
-function rewind(gj, outer) {
+export default function rewind(gj, outer) {
     var type = gj && gj.type, i;
 
     if (type === 'FeatureCollection') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,13 @@
       "license": "ISC",
       "dependencies": {
         "get-stream": "^6.0.1",
-        "minimist": "^1.2.6"
+        "minimist": "^1.2.7"
       },
       "bin": {
-        "geojson-rewind": "geojson-rewind"
+        "geojson-rewind": "geojson-rewind.js"
       },
       "devDependencies": {
+        "rollup": "^3.27.0",
         "tape": "^5.5.3"
       }
     },
@@ -231,6 +232,20 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -818,6 +833,22 @@
         "through": "~2.3.4"
       }
     },
+    "node_modules/rollup": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.0.tgz",
+      "integrity": "sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -1159,6 +1190,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1564,6 +1602,15 @@
       "dev": true,
       "requires": {
         "through": "~2.3.4"
+      }
+    },
+    "rollup": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.0.tgz",
+      "integrity": "sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.2"
       }
     },
     "side-channel": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.5.2",
   "description": "enforce winding order for geojson",
   "main": "index.js",
-  "bin": "geojson-rewind",
   "type": "module",
+  "bin": {
+    "geojson-rewind": "geojson-rewind.js"
+  },
   "directories": {
     "test": "test"
   },
@@ -13,7 +15,7 @@
   },
   "files": [
     "index.js",
-    "geojson-rewind"
+    "geojson-rewind.js"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "enforce winding order for geojson",
   "main": "index.cjs",
   "type": "module",
+  "module": "index.js",
   "bin": {
     "geojson-rewind": "geojson-rewind.js"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "enforce winding order for geojson",
   "main": "index.js",
   "bin": "geojson-rewind",
+  "type": "module",
   "directories": {
     "test": "test"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "minimist": "^1.2.7"
   },
   "devDependencies": {
-    "rollup": "^2.56.2",
+    "rollup": "^3.27.0",
     "tape": "^5.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,19 +2,25 @@
   "name": "@mapbox/geojson-rewind",
   "version": "0.5.2",
   "description": "enforce winding order for geojson",
-  "main": "index.js",
+  "main": "index.cjs",
   "type": "module",
   "bin": {
     "geojson-rewind": "geojson-rewind.js"
+  },
+  "exports": {
+    "import": "./index.js",
+    "require": "./index.cjs"
   },
   "directories": {
     "test": "test"
   },
   "scripts": {
-    "test": "tape test/rewind.js"
+    "test": "tape test/rewind.js",
+    "prepare": "rollup -c"
   },
   "files": [
     "index.js",
+    "index.cjs",
     "geojson-rewind.js"
   ],
   "repository": {
@@ -39,6 +45,7 @@
     "minimist": "^1.2.7"
   },
   "devDependencies": {
+    "rollup": "^2.56.2",
     "tape": "^5.5.3"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,8 @@
+export default {
+    input: 'index.js',
+    output: {
+        file: 'index.cjs',
+        format: 'cjs',
+        exports: 'auto'
+    }
+};

--- a/test/rewind.js
+++ b/test/rewind.js
@@ -1,6 +1,9 @@
-var rewind = require('../'),
-    fs = require('fs'),
-    test = require('tape');
+import rewind from "@mapbox/geojson-rewind";
+import fs from 'fs';
+import test from 'tape';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 function f(_) {
     return JSON.parse(fs.readFileSync(_, 'utf8'));


### PR DESCRIPTION
This PR updates the code to be in ES modules, and adds a build to retain compatibility with CJS contexts. To CJS users there should be no obvious change. One thing to note though, is that the CLI will now only work with Node 12.22 and up (all maintained versions of node are supported).

Closes #29